### PR TITLE
Sync fork to emqx v5.4.2

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -48,12 +48,15 @@ ENV LANG=C.UTF-8
 
 COPY deploy/docker/docker-entrypoint.sh /usr/bin/
 
+ARG UID=2002
+ARG GID=2002
+
 RUN set -eu; \
     apt-get update; \
     apt-get install -y --no-install-recommends ca-certificates procps $(echo "${EXTRA_DEPS}" | tr ',' ' '); \
     rm -rf /var/lib/apt/lists/*; \
-    groupadd -r -g 1000 emqx; \
-    useradd -r -m -u 1000 -g emqx emqx;
+    groupadd -r -g ${GID} emqx; \
+    useradd -r -m -u ${UID} -g emqx emqx;
 
 COPY --from=builder --chown=emqx:emqx /emqx-rel /opt/
 


### PR DESCRIPTION
Added `UID` and `GID` args allow control over which UID and GID is assigned to the `emqx` user and group which is used for execution.